### PR TITLE
Fix response read on long messages

### DIFF
--- a/aiomcrcon/client.py
+++ b/aiomcrcon/client.py
@@ -71,9 +71,17 @@ class Client:
         in_len = struct.unpack("<i", (await self._reader.read(4)))[0]
 
         # read rest of packet data
-        in_data = await self._reader.read(in_len)
+        in_arr = []
+        in_tlen = 0
+        while in_tlen < in_len:
+            in_tmp = await self._reader.read(in_len - in_tlen)
+            if not in_tmp:
+                break
+            in_tlen += len(in_tmp)
+            in_arr.append(in_tmp)
+        in_data = b''.join(in_arr)
 
-        if not in_data.endswith(b"\x00\x00"):
+        if len(in_data) != in_len or not in_data.endswith(b"\x00\x00"):
             raise ValueError("Invalid data received from server.")
 
         # decode the incoming request id and packet type


### PR DESCRIPTION
When running the "help" command, the read only returned 2916 of 2940 bytes.
Any response larger than the MTU could be truncated.
This change assembles the replies in an array and joins them when done.